### PR TITLE
README: minor tweak to specifically mention GNU Fortran

### DIFF
--- a/README
+++ b/README
@@ -368,6 +368,12 @@ Compiler Notes
     when Open MPI is built with a Fortran compiler that support the
     INTERFACE keyword and ISO_FORTRAN_ENV.
 
+    *** The Open MPI team has not tested to determine exactly which
+        version of the GNU Fortran compiler suite started supporting
+        what is required for MPI_SIZEOF.  We know that gfortran v4.8
+        (bundled in RHEL 7.x) supports the MPI_SIZEOF interfaces.
+        However, gfortran 4.4 (bundled in RHEL 6.x) does not.
+
   - The level of support provided by the mpi module is based on your
     Fortran compiler.
 


### PR DESCRIPTION
Lots of people still use GFortran, and lots of people still use somewhat old versions of it (e.g., if it's bundled in their older-but-still-installed Linux distros).  So let's specifically mention it.  This may be a bit overkill, but more specific docs are usually a Good Thing (i.e., they can prevent questions from being sent to the mailing list).

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>